### PR TITLE
Using Python's copy instead of Django's copycompat since it was deprecated

### DIFF
--- a/djxml/xmlmodels/base.py
+++ b/djxml/xmlmodels/base.py
@@ -3,13 +3,13 @@ import sys
 import codecs
 import functools
 
+import copy
 from lxml import etree
 
 from django.core.exceptions import (ObjectDoesNotExist, FieldError,
                                     MultipleObjectsReturned,)
 from django.db.models.base import subclass_exception
 from django.utils.encoding import smart_str, force_unicode
-import django.utils.copycompat as copy
 
 from . import signals
 from .options import Options, DEFAULT_NAMES

--- a/djxml/xmlmodels/fields.py
+++ b/djxml/xmlmodels/fields.py
@@ -1,8 +1,7 @@
 import re
 
+import copy
 from lxml import etree, isoschematron
-
-import django.utils.copycompat as copy
 
 from django.core.exceptions import ValidationError
 from django.utils.encoding import force_unicode


### PR DESCRIPTION
Hi there,

As you can see here ```django.utils.copycompat``` was deprecated with Django 1.6 and Python's ```copy``` needs to be used instead:

https://docs.djangoproject.com/en/1.6/internals/deprecation/

I've just made that little change in two files so we can use ```django-xml``` with the current versions of Django.

Regards,

Antonio Ognio
Lima-Peru