### PR TITLE
Added support for Django 2.1+ and Django 3.0/3.1

### DIFF
--- a/djxml/xmlmodels/base.py
+++ b/djxml/xmlmodels/base.py
@@ -68,11 +68,11 @@ class XmlModelBase(type):
         new_class.add_to_class('DoesNotExist', subclass_exception('DoesNotExist',
                 tuple(x.DoesNotExist
                         for x in parents if hasattr(x, '_meta'))
-                                or (ObjectDoesNotExist,), module))
+                                or (ObjectDoesNotExist,), module, None))
         new_class.add_to_class('MultipleObjectsReturned', subclass_exception('MultipleObjectsReturned',
                 tuple(x.MultipleObjectsReturned
                         for x in parents if hasattr(x, '_meta'))
-                                or (MultipleObjectsReturned,), module))
+                                or (MultipleObjectsReturned,), module, None))
 
         # Bail out early if we have already created this class.
         m = get_xml_model(new_class._meta.app_label, name, False)

--- a/djxml/xmlmodels/base.py
+++ b/djxml/xmlmodels/base.py
@@ -77,7 +77,7 @@ class XmlModelBase(type):
                     x.DoesNotExist for x in parents if hasattr(x, '_meta')
                 ) or (ObjectDoesNotExist,),
                 module,
-                =new_class))
+                new_class))
         new_class.add_to_class(
             'MultipleObjectsReturned',
             subclass_exception(

--- a/djxml/xmlmodels/base.py
+++ b/djxml/xmlmodels/base.py
@@ -68,11 +68,11 @@ class XmlModelBase(type):
         new_class.add_to_class('DoesNotExist', subclass_exception('DoesNotExist',
                 tuple(x.DoesNotExist
                         for x in parents if hasattr(x, '_meta'))
-                                or (ObjectDoesNotExist,), module, None))
+                                or (ObjectDoesNotExist,), module, new_class))
         new_class.add_to_class('MultipleObjectsReturned', subclass_exception('MultipleObjectsReturned',
                 tuple(x.MultipleObjectsReturned
                         for x in parents if hasattr(x, '_meta'))
-                                or (MultipleObjectsReturned,), module, None))
+                                or (MultipleObjectsReturned,), module, new_class))
 
         # Bail out early if we have already created this class.
         m = get_xml_model(new_class._meta.app_label, name, False)

--- a/djxml/xmlmodels/exceptions.py
+++ b/djxml/xmlmodels/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from django.core.exceptions import ValidationError
-from django.utils import six
+import six
 
 class XmlModelException(Exception):
     pass

--- a/djxml/xmlmodels/options.py
+++ b/djxml/xmlmodels/options.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 
 from lxml import etree
 
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
+
 try:
     from django.utils.encoding import smart_bytes as smart_str
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'pytz',
         'python-dateutil',
         'Django>=1.11',
+        'six',
     ],
     description="Provides an abstraction to lxml's XPath and XSLT " + \
                 "functionality in a manner resembling django database models",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     {py27}-django{111}
     {py34,py35,py36,py37}-django{111,20}
-    {py35,py36,py37}-django{22}
+    {py35,py36,py37}-django{21,22}
 
 [testenv]
 commands =
@@ -11,6 +11,7 @@ deps =
     six>=1.9.0
     django111: Django>=1.11,<2
     django20: Django>=2.0,<2.1
+    django22: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py27}-django{111}
-    {py34,py35,py36,py37}-django{111,20}
+    {py34,py35,py36,py37}-django{111,20,22}
 
 [testenv]
 commands =
@@ -10,6 +10,7 @@ deps =
     six>=1.9.0
     django111: Django>=1.11,<2
     django20: Django>=2.0,<2.1
+    django22: Django>=2.2,<2.3
 
 [testenv:pep8]
 description = Run PEP8 pycodestyle (flake8) against the djxml/ package directory

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     {py27}-django{111}
-    {py34,py35,py36,py37}-django{111,20,22}
+    {py34,py35,py36,py37}-django{111,20}
+    {py35,py36,py37}-django{22}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     six>=1.9.0
     django111: Django>=1.11,<2
     django20: Django>=2.0,<2.1
-    django22: Django>=2.1,<2.2
+    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py27-django111
-    {py35,py36,py37}-django{111,20,21,22,30,31}
+    {py35,py36,py37}-django{111,20,21,22,}
+    {py36,py37}-django{30,31}
 
 [testenv]
 commands =


### PR DESCRIPTION
The method signature for `subclass_exception` now requires the `attached_to` positional argument starting in Django 2.1+.