### PR TITLE
Py3 compat fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 dist: xenial
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,9 @@ resembling django database models.
 Note
 ====
 
-Version 2.0 drops support for Django < 1.11. Version 3.0 will drop support for 
-Python < 3.4.
+* Version 2.0 drops support for Django < 1.11
+* Version 2.0.1 drops support for Python 3.4
+* Version 3.0 will drop support for Python < 3.5
 
 
 Installation

--- a/djxml/xmlmodels/fields.py
+++ b/djxml/xmlmodels/fields.py
@@ -653,10 +653,10 @@ class SchematronField(XmlField):
             'store_report': True,
             'store_schematron': True,
         }
-
-        for k in self.schematron_kwargs.keys():
-            if self.schematron_kwargs[k] is None:
-                del self.schematron_kwargs[k]
+        self.schematron_kwargs = {
+            k: v for k, v in self.schematron_kwargs.items()
+            if v is not None
+        }
 
         super(SchematronField, self).__init__(**kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except IOError:
 
 setup(
     name='django-xml',
-    version="2.0.0",
+    version="2.0.1",
     install_requires=[
         'lxml',
         'pytz',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py27}-django{111}
-    {py34,py35,py36,py37}-django{111,20}
+    {py35,py36,py37}-django{111,20}
 
 [testenv]
 commands =


### PR DESCRIPTION
Can't change a `dict` during iteration. In Py2 `dict.keys()` returned a list, in Py3 it return an iterator.