### PR TITLE
Fix python 3.6 deprecation warning for empty xmlmodel super() calls

### DIFF
--- a/djxml/xmlmodels/base.py
+++ b/djxml/xmlmodels/base.py
@@ -36,7 +36,12 @@ class XmlModelBase(type):
 
         # Create the class.
         module = attrs.pop('__module__')
-        new_class = super_new(cls, name, bases, {'__module__': module})
+        new_attrs = {'__module__': module}
+        classcell = attrs.pop('__classcell__', None)
+        if classcell is not None:
+            new_attrs['__classcell__'] = classcell
+        new_class = super_new(cls, name, bases, new_attrs)
+
         attr_meta = attrs.pop('Meta', None)
         if not attr_meta:
             meta = getattr(new_class, 'Meta', None)


### PR DESCRIPTION
This fix is patterned on the analogous fix in django `ModelBase.__new__`, which was the basis for `XmlModelBase`. See django/django#7653